### PR TITLE
add default scaling strategy to engine

### DIFF
--- a/deploy/crd/autoscaling-engine.yaml
+++ b/deploy/crd/autoscaling-engine.yaml
@@ -26,5 +26,7 @@ spec:
           properties:
             type:
               type: string
+            defaultScalingStrategy:
+              type: string  
             configuration:
               type: object

--- a/deploy/example/autoscalingengine.yaml
+++ b/deploy/example/autoscalingengine.yaml
@@ -4,6 +4,7 @@ metadata:
   name: containership
 spec:
   type: containership
+  defaultScalingStrategy: random
   configuration:
     address: https://stage-provision.containership.io
     tokenEnvVarName: CONTAINERSHIP_CLOUD_CLUSTER_API_KEY

--- a/pkg/apis/cerebral.containership.io/v1alpha1/types.go
+++ b/pkg/apis/cerebral.containership.io/v1alpha1/types.go
@@ -142,8 +142,9 @@ type AutoscalingEngine struct {
 
 // AutoscalingEngineSpec describes the spec for the AutoscalingEngine
 type AutoscalingEngineSpec struct {
-	Type          string            `json:"type"`
-	Configuration map[string]string `json:"configuration"`
+	Type                   string            `json:"type"`
+	DefaultScalingStrategy string            `json:"defaultScalingStrategy"`
+	Configuration          map[string]string `json:"configuration"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
 ### Description

The autoscaling engine should be able to have a default strategy for scaling so that an autoscaling strategy is not defined on the autoscaling group it uses the engines default strategy in scale cases. 


The actual autoscaling engine needs to be changed to use this new property but I am waitron for PR #23 before refactoring that. I just wanted to throw this PR up so I don't forget to do it. 

 #### What does this pull request accomplish?

 #### What issue(s) does this fix?

 #### Additional Considerations

 ### Testing

 #### Setup

 #### Instructions

