### PR TITLE
fix crd deploys validation for field adjustmentValue

### DIFF
--- a/deploy/crd/autoscaling-policy.yaml
+++ b/deploy/crd/autoscaling-policy.yaml
@@ -50,7 +50,8 @@ spec:
                       type: string
                       enum: [ "absolute", "percent" ]
                     adjustmentValue:
-                      type: integer
+                      type: number
+                      format: float
                       minimum: 0
                 scaleDown:
                   type: object
@@ -65,7 +66,8 @@ spec:
                       type: string
                       enum: [ "absolute", "percent" ]
                     adjustmentValue:
-                      type: integer
+                      type: number
+                      format: float
                       minimum: 0
             pollInterval:
               type: integer


### PR DESCRIPTION
 ### Description

 #### What does this pull request accomplish?

Update CRD ASP in deploy to use type number for adjustmentValue. This allows the percent adjustmentType to be used and the adjustmentValues to be valid, ex. 0.1. 

 #### What issue(s) does this fix?

 #### Additional Considerations

 ### Testing

`kubectl apply -f deploy/crd`

which was able to be created. 

```
...
customresourcedefinition.apiextensions.k8s.io "autoscalingpolicies.cerebral.containership.io" created
...
```

 #### Setup

 #### Instructions

 ### Dependencies