### PR TITLE
Add events attached to ASGs, fix bug where ignoring error

### DIFF
--- a/cmd/cerebral/cerebral.go
+++ b/cmd/cerebral/cerebral.go
@@ -11,6 +11,7 @@ import (
 
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/containership/cerebral/pkg/autoscalingengine/containership"
 	"github.com/containership/cerebral/pkg/buildinfo"
 	cerebral "github.com/containership/cerebral/pkg/client/clientset/versioned"
+	cerebralscheme "github.com/containership/cerebral/pkg/client/clientset/versioned/scheme"
 	cinformers "github.com/containership/cerebral/pkg/client/informers/externalversions"
 	"github.com/containership/cerebral/pkg/controller"
 
@@ -51,6 +53,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to create Cerebral clientset: %+v", err)
 	}
+
+	// Add cerebral scheme so we can record events
+	cerebralscheme.AddToScheme(scheme.Scheme)
 
 	kubeInformerFactory := informers.NewSharedInformerFactory(kubeclientset, 30*time.Second)
 	cerebralInformerFactory := cinformers.NewSharedInformerFactory(cerebralclientset, 30*time.Second)

--- a/pkg/controller/metrics_backend.go
+++ b/pkg/controller/metrics_backend.go
@@ -8,15 +8,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	corev1 "k8s.io/api/core/v1"
-
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/scheme"
-	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	corelistersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/containership/cluster-manager/pkg/log"
@@ -61,8 +56,6 @@ type MetricsBackendController struct {
 	podSynced cache.InformerSynced
 
 	workqueue workqueue.RateLimitingInterface
-
-	recorder record.EventRecorder
 }
 
 // NewMetricsBackend constructs a new MetricsBackend
@@ -77,15 +70,6 @@ func NewMetricsBackend(kubeclientset kubernetes.Interface,
 		cerebralclientset: cerebralclientset,
 		workqueue:         workqueue.NewNamedRateLimitingQueue(rateLimiter, metricsBackendControllerName),
 	}
-
-	eventBroadcaster := record.NewBroadcaster()
-	eventBroadcaster.StartLogging(log.Infof)
-	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{
-		Interface: kubeclientset.CoreV1().Events(""),
-	})
-	c.recorder = eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{
-		Component: metricsBackendControllerName,
-	})
 
 	metricsBackendInformer := cInformerFactory.Cerebral().V1alpha1().MetricsBackends()
 

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -1,8 +1,19 @@
 package events
 
 const (
+	// ScaleUpAlerted event is created when an AutoscalingPolicy scale up alert occurs
+	ScaleUpAlerted = "ScaleUpAlerted"
+	// ScaleDownAlerted event is created when an AutoscalingPolicy scale down alert occurs
+	ScaleDownAlerted = "ScaleDownAlerted"
+
 	// ScaledUp event is created when an AutoscalingGroup is scaled up
 	ScaledUp = "ScaledUp"
 	// ScaledDown event is created when an AutoscalingGroup is scaled down
 	ScaledDown = "ScaledDown"
+
+	// ScaleIgnored event is created when a scale event is ignored
+	ScaleIgnored = "ScaleIgnored"
+
+	// ScaleError event is created when a scale event errors
+	ScaleError = "ScaleError"
 )


### PR DESCRIPTION
### Description

 #### What does this pull request accomplish?

- Add events attached to ASGs
- Fix bug where we were silently ignoring errors returned by engine

This does not yet include the `ScaleUpAlerted` and `ScaleDownAlerted` events that will be attached to ASPs.
Those will be in a follow-up PR.

 #### What issue(s) does this fix?
* Working towards #26

 #### Additional Considerations

 ### Testing

See events printed:

```
2018-12-09T10:49:27.577-0800    INFO    Event(v1.ObjectReference{Kind:"AutoscalingGroup", Namespace:"", Name:"tester", UID:"b95ea3a8-f99f-11e8-8a80-0697bcac5b18", APIVersion:"cerebral.containership.io/v1alpha1", ResourceVersion:"393237", FieldPath:""}): type: 'Warning' reason: 'ScaleIgnored' scale up operation would exceed upper bound of 3 nodes
```

 ### Dependencies
* None