### PR TITLE
Use mem available for Prometheus memory query

### DIFF
--- a/pkg/metrics/backends/prometheus/prometheus.go
+++ b/pkg/metrics/backends/prometheus/prometheus.go
@@ -46,11 +46,7 @@ var cpuQueryTemplate = template.Must(template.New("cpu").Parse(cpuQueryTemplateS
 // Average memory usage across the given nodes for the given range
 const memoryQueryTemplateString = `
 100 * {{.Aggregation}}(
-	1 - ((
-			avg_over_time(node_memory_MemFree{instance=~'{{.InstancesRegex}}'}[{{.Range}}])
-			  + avg_over_time(node_memory_Cached{instance=~'{{.InstancesRegex}}'}[{{.Range}}])
-			  + avg_over_time(node_memory_Buffers{instance=~'{{.InstancesRegex}}'}[{{.Range}}])
-		  )
+	1 - (avg_over_time(node_memory_MemAvailable{instance=~'{{.InstancesRegex}}'}[{{.Range}}])
 		  / avg_over_time(node_memory_MemTotal{instance=~'{{.InstancesRegex}}'}[{{.Range}}]))
 )`
 


### PR DESCRIPTION
### Description

 #### What does this pull request accomplish?

- Use mem available for Prometheus memory query
- Aligns with https://github.com/containership/cloud.ui/pull/3022

 #### What issue(s) does this fix?
* None, working toward #14

 #### Additional Considerations

 ### Testing

 ```
2018-12-09T11:09:02.790-0800    DEBUG   Performing prometheus query:
100 * avg(
        1 - (avg_over_time(node_memory_MemAvailable{instance=~'192.168.3.4:.*|192.168.2.4:.*|192.168.1.8:.*'}[1m])
                  / avg_over_time(node_memory_MemTotal{instance=~'192.168.3.4:.*|192.168.2.4:.*|192.168.1.8:.*'}[1m]))
)
2018-12-09T11:09:02.883-0800    DEBUG   Poller for ASP "prometheus-cpu-percentage" got value 34.219833
 ```

 ### Dependencies
* None