### PR TITLE
Fix buildMemoryQuery tests that were calling buildCPUQuery

### DIFF
--- a/pkg/metrics/backends/prometheus/prometheus_test.go
+++ b/pkg/metrics/backends/prometheus/prometheus_test.go
@@ -232,10 +232,10 @@ func TestBuildMemoryQuery(t *testing.T) {
 	_, err := buildMemoryQuery(oneIP, goodConfiguration)
 	assert.NoError(t, err, "good configuration is ok")
 
-	_, err = buildCPUQuery(oneIP, emptyConfiguration)
+	_, err = buildMemoryQuery(oneIP, emptyConfiguration)
 	assert.NoError(t, err, "empty configuration is ok (defaults)")
 
-	_, err = buildCPUQuery(oneIP, badAggregationConfiguration)
+	_, err = buildMemoryQuery(oneIP, badAggregationConfiguration)
 	assert.Error(t, err, "invalid aggregation errors")
 }
 


### PR DESCRIPTION
 ### Description

 #### What does this pull request accomplish?
Fixes `TestBuildMemoryQuery` tests by removing calls to `buildCPUQuery` and replacing them with calls to `buildMemoryQuery`.

 #### What issue(s) does this fix?
N/A

 #### Additional Considerations
N/A

 ### Testing

 #### Setup
N/A

 #### Instructions
`make test`

 ### Dependencies
N/A
