### PR TITLE
return error from GetValue when building query fails

### DIFF
--- a/pkg/metrics/backends/prometheus/prometheus.go
+++ b/pkg/metrics/backends/prometheus/prometheus.go
@@ -100,15 +100,24 @@ func (b Backend) GetValue(metric string, configuration map[string]string, nodeSe
 
 	switch metric {
 	case MetricCPUPercentUtilization.String():
-		query, _ := buildCPUQuery(podIPs, configuration)
+		query, err := buildCPUQuery(podIPs, configuration)
+		if err != nil {
+			return 0, errors.Wrap(err, "building query")
+		}
 		return b.performQuery(query)
 
 	case MetricMemoryPercentUtilization.String():
-		query, _ := buildMemoryQuery(podIPs, configuration)
+		query, err := buildMemoryQuery(podIPs, configuration)
+		if err != nil {
+			return 0, errors.Wrap(err, "building query")
+		}
 		return b.performQuery(query)
 
 	case MetricCustom.String():
-		query, _ := buildCustomQuery(podIPs, configuration)
+		query, err := buildCustomQuery(podIPs, configuration)
+		if err != nil {
+			return 0, errors.Wrap(err, "building query")
+		}
 		return b.performQuery(query)
 
 	default:


### PR DESCRIPTION
 ### Description

 #### What does this pull request accomplish?
Return error from `GetValue` when building Prometheus query fails. We can avoid calling `PerformQuery` since we know the query will fail.

 #### What issue(s) does this fix?
N/A

 #### Additional Considerations
N/A

 ### Testing

 #### Setup
N/A

 #### Instructions
`make test`

 ### Dependencies
N/A
