### PR TITLE
add Kubernetes metrics backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Support for a different `MetricsBackend` can be added by implementing the [metri
 In addition to traditional metrics backends such as the currently available Prometheus integration, there are countless possible use-cases for custom, application-specific metrics backends.
 For example, autoscaling could be performed based on the current depth of some application queue.
 
+The currently available metrics backends include:
+* [Kubernetes][kubernetes-metrics-backend]
+* Prometheus
+
 #### Autoscaling Engine
 
 Support for a different `AutoscalingEngine` can be added by implementing the [engine interface][engine-interface].
@@ -91,3 +95,4 @@ See [CONTRIBUTING.md](/CONTRIBUTING.md) for more details.
 
 [metrics-backend-interface]: https://github.com/containership/cerebral/blob/master/pkg/metrics/backend.go
 [engine-interface]: https://github.com/containership/cerebral/blob/master/pkg/autoscaling/engine.go
+[kubernetes-metrics-backend]: https://github.com/containership/cerebral/blob/master/docs/metrics_backends/kubernetes.md

--- a/docs/metrics_backends/kubernetes.md
+++ b/docs/metrics_backends/kubernetes.md
@@ -1,0 +1,167 @@
+# Kubernetes Metrics Backend
+
+## Description
+The Kubernetes metrics backend interfaces with the Kubernetes API to expose allocation metrics gathered by querying for pod resource requests.
+
+## Configuration
+Since the Kubernetes metrics backend implementation uses an in-cluster configuration, no additional configuration is required.
+
+## Example
+```yaml
+apiVersion: cerebral.containership.io/v1alpha1
+kind: MetricsBackend
+metadata:
+  name: kubernetes
+spec:
+  type: kubernetes
+```
+
+## Available Metrics
+* [CPU Percent Allocation](#cpu-percent-allocation)
+* [Memory Percent Allocation](#memory-percent-allocation)
+* [Ephemeral Storage Percent Allocation](#ephemeral-storage-percent-allocation)
+* [Pod Percent Allocation](#pod-percent-allocation)
+
+### CPU Percent Allocation
+
+#### Description
+Returns the percent of allocated CPUs across the nodes in the autoscaling group by summing the total CPU requests of the pods, and dividing by the nodes' total allocatable CPUs.
+
+#### Metric
+`cpu_percent_allocation`
+
+#### Configuration
+No configuration is available for this metric type.
+
+#### Example
+```yaml
+apiVersion: cerebral.containership.io/v1alpha1
+kind: AutoscalingPolicy
+metadata:
+  name: cpu-example-policy
+spec:
+  metric: cpu_percent_allocation
+  metricConfiguration: {}
+  metricsBackend: kubernetes
+  pollInterval: 15
+  samplePeriod: 300
+  scalingPolicy:
+    scaleDown:
+      adjustmentType: absolute
+      adjustmentValue: 1
+      comparisonOperator: <=
+      threshold: 30
+    scaleUp:
+      adjustmentType: absolute
+      adjustmentValue: 2
+      comparisonOperator: '>='
+      threshold: 70
+```
+
+### Memory Percent Allocation
+
+#### Description
+Returns the percent of allocated memory across the nodes in the autoscaling group by summing the total memory requests of the pods, and dividing by the nodes' total allocatable memory.
+
+#### Metric
+`memory_percent_allocation`
+
+#### Configuration
+No configuration is available for this metric type.
+
+#### Example
+```yaml
+apiVersion: cerebral.containership.io/v1alpha1
+kind: AutoscalingPolicy
+metadata:
+  name: memory-example-policy
+spec:
+  metric: memory_percent_allocation
+  metricConfiguration: {}
+  metricsBackend: kubernetes
+  pollInterval: 15
+  samplePeriod: 300
+  scalingPolicy:
+    scaleDown:
+      adjustmentType: absolute
+      adjustmentValue: 1
+      comparisonOperator: <=
+      threshold: 30
+    scaleUp:
+      adjustmentType: absolute
+      adjustmentValue: 2
+      comparisonOperator: '>='
+      threshold: 70
+```
+
+### Ephemeral Storage Percent Allocation
+
+#### Description
+Returns the percent of allocated ephemeral storage across the nodes in the autoscaling group by summing the total ephemeral storage requests of the pods, and dividing by the nodes' total allocatable ephemeral storage.
+
+#### Metric
+`ephemeral_storage_percent_allocation`
+
+#### Configuration
+No configuration is available for this metric type.
+
+#### Example
+```yaml
+apiVersion: cerebral.containership.io/v1alpha1
+kind: AutoscalingPolicy
+metadata:
+  name: ephemeral-storage-example-policy
+spec:
+  metric: ephemeral_storage_percent_allocation
+  metricConfiguration: {}
+  metricsBackend: kubernetes
+  pollInterval: 15
+  samplePeriod: 300
+  scalingPolicy:
+    scaleDown:
+      adjustmentType: absolute
+      adjustmentValue: 1
+      comparisonOperator: <=
+      threshold: 30
+    scaleUp:
+      adjustmentType: absolute
+      adjustmentValue: 2
+      comparisonOperator: '>='
+      threshold: 70
+```
+
+### Pod Percent Allocation
+
+#### Description
+Returns the percent of allocated pods across the nodes in the autoscaling group by summing the total number of pods running on the nodes, and dividing by the nodes' total allocatable pods.
+
+#### Metric
+`pod_percent_allocation`
+
+#### Configuration
+No configuration is available for this metric type.
+
+#### Example
+```yaml
+apiVersion: cerebral.containership.io/v1alpha1
+kind: AutoscalingPolicy
+metadata:
+  name: pod-example-policy
+spec:
+  metric: pod_percent_allocation
+  metricConfiguration: {}
+  metricsBackend: kubernetes
+  pollInterval: 15
+  samplePeriod: 300
+  scalingPolicy:
+    scaleDown:
+      adjustmentType: absolute
+      adjustmentValue: 1
+      comparisonOperator: <=
+      threshold: 30
+    scaleUp:
+      adjustmentType: absolute
+      adjustmentValue: 2
+      comparisonOperator: '>='
+      threshold: 70
+```

--- a/pkg/controller/metrics_backend.go
+++ b/pkg/controller/metrics_backend.go
@@ -22,6 +22,7 @@ import (
 	clisters "github.com/containership/cerebral/pkg/client/listers/cerebral.containership.io/v1alpha1"
 
 	"github.com/containership/cerebral/pkg/metrics"
+	k8smb "github.com/containership/cerebral/pkg/metrics/backends/kubernetes"
 	"github.com/containership/cerebral/pkg/metrics/backends/prometheus"
 
 	"github.com/pkg/errors"
@@ -251,6 +252,8 @@ func (c *MetricsBackendController) syncHandler(key string) error {
 // It should be the only function that knows how to instantiate a particular backend type.
 func (c *MetricsBackendController) instantiateBackend(backend *cerebralv1alpha1.MetricsBackend) (metrics.Backend, error) {
 	switch backend.Spec.Type {
+	case "kubernetes":
+		return k8smb.NewClient(c.nodeLister, c.podLister)
 	case "prometheus":
 		var address string
 		var ok bool

--- a/pkg/metrics/backends/kubernetes/kubernetes.go
+++ b/pkg/metrics/backends/kubernetes/kubernetes.go
@@ -1,0 +1,165 @@
+package kubernetes
+
+import (
+	"github.com/pkg/errors"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	corelistersv1 "k8s.io/client-go/listers/core/v1"
+
+	"github.com/containership/cerebral/pkg/metrics"
+	"github.com/containership/cerebral/pkg/nodeutil"
+	"github.com/containership/cluster-manager/pkg/log"
+)
+
+// Backend implements a metrics backend for Kubernetes. It requires a pod
+// lister so that it can gather info about where pods are running.
+type Backend struct {
+	nodeLister corelistersv1.NodeLister
+	podLister  corelistersv1.PodLister
+}
+
+// NewClient returns a new client for talking to a Kubernetes Backend, or an error
+func NewClient(nodeLister corelistersv1.NodeLister, podLister corelistersv1.PodLister) (metrics.Backend, error) {
+	if nodeLister == nil {
+		return nil, errors.New("node lister must be provided")
+	}
+
+	if podLister == nil {
+		return nil, errors.New("pod lister must be provided")
+	}
+
+	return Backend{
+		nodeLister: nodeLister,
+		podLister:  podLister,
+	}, nil
+}
+
+// GetValue implements the metrics.Backend interface
+func (b Backend) GetValue(metric string, configuration map[string]string, nodeSelector map[string]string) (float64, error) {
+	selector := nodeutil.GetNodesLabelSelector(nodeSelector)
+	nodes, err := b.nodeLister.List(selector)
+	if err != nil {
+		return 0, errors.Wrap(err, "listing nodes")
+	}
+
+	pods, err := b.getPodsOnNodes(nodes)
+	if err != nil {
+		return 0, errors.Wrapf(err, "getting pods on nodes for metric %s", metric)
+	}
+
+	switch metric {
+	case MetricCPUPercentAllocation.String():
+		value := b.calculateCPUAllocationPercentage(pods, nodes)
+		return value, nil
+
+	case MetricMemoryPercentAllocation.String():
+		value := b.calculateMemoryAllocationPercentage(pods, nodes)
+		return value, nil
+
+	case MetricEphemeralStoragePercentAllocation.String():
+		value := b.calculateEphemeralStorageAllocationPercentage(pods, nodes)
+		return value, nil
+
+	case MetricPodPercentAllocation.String():
+		value := b.calculatePodAllocationPercentage(pods, nodes)
+		return value, nil
+
+	default:
+		return 0, errors.Errorf("unknown metric %q", metric)
+	}
+}
+
+func (b Backend) getPodsOnNodes(nodes []*corev1.Node) ([]*corev1.Pod, error) {
+	var podsOnNodes []*corev1.Pod
+
+	// Pass an empty selector to list all pods
+	pods, err := b.podLister.List(labels.NewSelector())
+	if err != nil {
+		return nil, errors.Wrap(err, "listing pods")
+	}
+
+	// Only filter to pods running on nodes we care about
+	for _, pod := range pods {
+		for _, node := range nodes {
+			if pod.Spec.NodeName == node.ObjectMeta.Name {
+				podsOnNodes = append(podsOnNodes, pod)
+			}
+		}
+	}
+
+	return podsOnNodes, nil
+}
+
+func (b Backend) calculateCPUAllocationPercentage(pods []*corev1.Pod, nodes []*corev1.Node) float64 {
+	log.Debugf("Performing cpu allocation calculation of %d pods across %d nodes", len(pods), len(nodes))
+
+	var allocatableCPUs, requestedCPUs int64
+
+	// calculate sum of allocatable CPUs across nodes
+	for _, node := range nodes {
+		allocatableCPUs += node.Status.Allocatable.Cpu().Value()
+	}
+
+	// calculate sum of requested CPUs across pods
+	for _, pod := range pods {
+		for _, container := range pod.Spec.Containers {
+			requestedCPUs += container.Resources.Requests.Cpu().Value()
+		}
+	}
+
+	return (100 * (float64(requestedCPUs) / float64(allocatableCPUs)))
+}
+
+func (b Backend) calculateMemoryAllocationPercentage(pods []*corev1.Pod, nodes []*corev1.Node) float64 {
+	log.Debugf("Performing memory allocation calculation of %d pods across %d nodes", len(pods), len(nodes))
+
+	var allocatableMemory, requestedMemory int64
+
+	// calculate sum of allocatable memory across nodes
+	for _, node := range nodes {
+		allocatableMemory += node.Status.Allocatable.Memory().Value()
+	}
+
+	// calculate sum of requested memory across pods
+	for _, pod := range pods {
+		for _, container := range pod.Spec.Containers {
+			requestedMemory += container.Resources.Requests.Memory().Value()
+		}
+	}
+
+	return (100 * (float64(requestedMemory) / float64(allocatableMemory)))
+}
+
+func (b Backend) calculateEphemeralStorageAllocationPercentage(pods []*corev1.Pod, nodes []*corev1.Node) float64 {
+	log.Debugf("Performing ephemeral storage allocation calculation of %d pods across %d nodes", len(pods), len(nodes))
+
+	var allocatableStorage, requestedStorage int64
+
+	// calculate sum of allocatable ephemeral storage across nodes
+	for _, node := range nodes {
+		allocatableStorage += node.Status.Allocatable.StorageEphemeral().Value()
+	}
+
+	// calculate sum of requested ephemeral storage across pods
+	for _, pod := range pods {
+		for _, container := range pod.Spec.Containers {
+			requestedStorage += container.Resources.Requests.StorageEphemeral().Value()
+		}
+	}
+
+	return (100 * (float64(requestedStorage) / float64(allocatableStorage)))
+}
+
+func (b Backend) calculatePodAllocationPercentage(pods []*corev1.Pod, nodes []*corev1.Node) float64 {
+	log.Debugf("Performing pod allocation calculation of %d pods across %d nodes", len(pods), len(nodes))
+
+	var allocatablePods int64
+
+	// calculate sum of allocatable pods across nodes
+	for _, node := range nodes {
+		allocatablePods += node.Status.Allocatable.Pods().Value()
+	}
+
+	return (100 * (float64(len(pods)) / float64(allocatablePods)))
+}

--- a/pkg/metrics/backends/kubernetes/kubernetes_test.go
+++ b/pkg/metrics/backends/kubernetes/kubernetes_test.go
@@ -1,0 +1,216 @@
+package kubernetes
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	corelistersv1 "k8s.io/client-go/listers/core/v1"
+)
+
+var (
+	nodeAllocatable = corev1.ResourceList{
+		corev1.ResourceCPU:              *resource.NewQuantity(2, resource.DecimalSI),
+		corev1.ResourceMemory:           *resource.NewQuantity(1024, resource.DecimalSI),
+		corev1.ResourceEphemeralStorage: *resource.NewQuantity(4096, resource.DecimalSI),
+		corev1.ResourcePods:             *resource.NewQuantity(2, resource.DecimalSI),
+	}
+)
+
+var (
+	node0 = &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-0",
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: nodeAllocatable,
+		},
+	}
+	node1 = &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-1",
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: nodeAllocatable,
+		},
+	}
+	node2 = &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-2",
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: nodeAllocatable,
+		},
+	}
+
+	pod0 = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-0",
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: node0.ObjectMeta.Name,
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:              *resource.NewQuantity(1, resource.DecimalSI),
+							corev1.ResourceMemory:           *resource.NewQuantity(256, resource.DecimalSI),
+							corev1.ResourceEphemeralStorage: *resource.NewQuantity(1024, resource.DecimalSI),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	pod1 = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-1",
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: node1.ObjectMeta.Name,
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:              *resource.NewQuantity(2, resource.DecimalSI),
+							corev1.ResourceMemory:           *resource.NewQuantity(512, resource.DecimalSI),
+							corev1.ResourceEphemeralStorage: *resource.NewQuantity(2048, resource.DecimalSI),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	pod2 = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-2",
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: node1.ObjectMeta.Name,
+		},
+	}
+)
+
+var backend = Backend{
+	nodeLister: buildNodeLister([]corev1.Node{*node0, *node1, *node2}),
+	podLister:  buildPodLister([]corev1.Pod{*pod0, *pod1, *pod2}),
+}
+
+func TestGetValue(t *testing.T) {
+	_, err := backend.GetValue("cpu_percent_allocation", nil, nil)
+	assert.NoError(t, err, "successfully get cpu allocation metric")
+
+	_, err = backend.GetValue("memory_percent_allocation", nil, nil)
+	assert.NoError(t, err, "successfully get memory allocation metric")
+
+	_, err = backend.GetValue("ephemeral_storage_percent_allocation", nil, nil)
+	assert.NoError(t, err, "successfully get ephemeral storage allocation metric")
+
+	_, err = backend.GetValue("pod_percent_allocation", nil, nil)
+	assert.NoError(t, err, "successfully get pod allocation metric")
+
+	_, err = backend.GetValue("not a valid metric", nil, nil)
+	assert.Error(t, err, "unknown metric requested")
+}
+
+func TestGetPodsOnNodes(t *testing.T) {
+	var emptyNodeList = []*corev1.Node{}
+	var singleNodeList = []*corev1.Node{node0}
+	var multipleNodeList = []*corev1.Node{node0, node1, node2}
+
+	pods, _ := backend.getPodsOnNodes(nil)
+	assert.Empty(t, pods, "nil node list returns empty array")
+
+	pods, _ = backend.getPodsOnNodes(emptyNodeList)
+	assert.Empty(t, pods, "empty node list returns empty array")
+
+	pods, _ = backend.getPodsOnNodes(singleNodeList)
+	assert.Equal(t, 1, len(pods), "returns single result")
+
+	pods, _ = backend.getPodsOnNodes(multipleNodeList)
+	assert.Equal(t, 3, len(pods), "returns three results")
+}
+
+func TestCalculateCPUAllocationPercentage(t *testing.T) {
+	var podList = []*corev1.Pod{pod0, pod1, pod2}
+	var nodeList = []*corev1.Node{node0, node1, node2}
+
+	percentage := backend.calculateCPUAllocationPercentage(podList, nodeList)
+	assert.Equal(t, float64(50), percentage, "returns correct allocation percentage")
+}
+
+func TestCalculateMemoryAllocationPercentage(t *testing.T) {
+	var podList = []*corev1.Pod{pod0, pod1, pod2}
+	var nodeList = []*corev1.Node{node0, node1, node2}
+
+	percentage := backend.calculateMemoryAllocationPercentage(podList, nodeList)
+	assert.Equal(t, float64(25), percentage, "returns correct allocation percentage")
+}
+
+func TestCalculateEphemeralStorageAllocationPercentage(t *testing.T) {
+	var podList = []*corev1.Pod{pod0, pod1, pod2}
+	var nodeList = []*corev1.Node{node0, node1, node2}
+
+	percentage := backend.calculateEphemeralStorageAllocationPercentage(podList, nodeList)
+	assert.Equal(t, float64(25), percentage, "returns correct allocation percentage")
+}
+
+func TestCalculatePodAllocationPercentage(t *testing.T) {
+	var podList = []*corev1.Pod{pod0, pod1, pod2}
+	var nodeList = []*corev1.Node{node0, node1, node2}
+
+	percentage := backend.calculatePodAllocationPercentage(podList, nodeList)
+	assert.Equal(t, float64(50), percentage, "returns correct allocation percentage")
+}
+
+// Get a node lister. Copies of the nodes are added to the cache; not the nodes themselves.
+func buildNodeLister(nodes []corev1.Node) corelistersv1.NodeLister {
+	// We don't need anything related to the client or informer; we're simply
+	// using this as an easy way to build a cache
+	client := &fake.Clientset{}
+	kubeInformerFactory := informers.NewSharedInformerFactory(client, 30*time.Second)
+	informer := kubeInformerFactory.Core().V1().Nodes()
+
+	for _, node := range nodes {
+		// TODO why is DeepCopy() required here? Without it, each Add() duplicates
+		// the first member added.
+		err := informer.Informer().GetStore().Add(node.DeepCopy())
+		if err != nil {
+			// Should be a programming error
+			panic(err)
+		}
+	}
+
+	return informer.Lister()
+}
+
+// Get a pod lister. Copies of the pods are added to the cache; not the pods themselves.
+func buildPodLister(pods []corev1.Pod) corelistersv1.PodLister {
+	// We don't need anything related to the client or informer; we're simply
+	// using this as an easy way to build a cache
+	client := &fake.Clientset{}
+	kubeInformerFactory := informers.NewSharedInformerFactory(client, 30*time.Second)
+	informer := kubeInformerFactory.Core().V1().Pods()
+
+	for _, pod := range pods {
+		// TODO why is DeepCopy() required here? Without it, each Add() duplicates
+		// the first member added.
+		err := informer.Informer().GetStore().Add(pod.DeepCopy())
+		if err != nil {
+			// Should be a programming error
+			panic(err)
+		}
+	}
+
+	return informer.Lister()
+}

--- a/pkg/metrics/backends/kubernetes/metrics.go
+++ b/pkg/metrics/backends/kubernetes/metrics.go
@@ -1,0 +1,31 @@
+package kubernetes
+
+// Metric is a metric exposed by this backend
+type Metric int
+
+const (
+	// MetricCPUPercentAllocation is used to gather info about the CPU allocation of nodes
+	MetricCPUPercentAllocation Metric = iota
+	// MetricMemoryPercentAllocation is used to gather info about the memory allocation of nodes
+	MetricMemoryPercentAllocation
+	// MetricEphemeralStoragePercentAllocation is used to gather info about the disk allocation of nodes
+	MetricEphemeralStoragePercentAllocation
+	// MetricPodPercentAllocation is used to gather info about the Pod allocation of nodes
+	MetricPodPercentAllocation
+)
+
+// String is a stringer for Metric
+func (m Metric) String() string {
+	switch m {
+	case MetricCPUPercentAllocation:
+		return "cpu_percent_allocation"
+	case MetricMemoryPercentAllocation:
+		return "memory_percent_allocation"
+	case MetricEphemeralStoragePercentAllocation:
+		return "ephemeral_storage_percent_allocation"
+	case MetricPodPercentAllocation:
+		return "pod_percent_allocation"
+	}
+
+	return "unknown"
+}


### PR DESCRIPTION
 ### Description

 #### What does this pull request accomplish?
Add Kubernetes metrics backend with support for various allocation metrics including `cpu_percent_allocation`, `memory_percent_allocation`, `ephemeral_storage_percent_allocation`, and `pod_percent_allocation`.

 #### What issue(s) does this fix?
* Fixes #51

 #### Additional Considerations
It may be worth spitting #51 into multiple issues. Raw value metrics can easily be added to the base laid down in this PR.

 ### Testing

 #### Setup
* Build image

 #### Instructions
* Update live Cerebral instance with local image
* Add Kubernetes MetricsBackend
* Add AutoscalingPolicy using Kubernetes MetricsBackend
* Verify output

 ### Dependencies
N/A