### PR TITLE
Default configuration address if not provided

### DIFF
--- a/docs/engines/containership.md
+++ b/docs/engines/containership.md
@@ -7,12 +7,12 @@ The Containership engine integrates with [Containership Kubernetes Engine](https
 ## Configuration
 In order for the Containership engine to scale your cluster, you will need various configuration parameters.
 
-| Field | Required | Type | Description |
-| ----- | -------- | ---- | ----------- |
-| `address` | true | string | The Containership provision API address. The parameter should be set to `https://provision.containership.io` |
-| `tokenEnvVarName` | true | string | The environment variable name to use to get the Containership API token. |
-| `organizationID` | true | string | The ID of the organization to which the cluster belongs. You can find this value on the "Organization Settings" page in Containership Cloud. |
-| `clusterID` | true | string | The ID of the cluster that should be monitored and scaled. You can find this value in your URL once you click into a cluster in Containership Cloud. |
+| Field | Required | Default | Type | Description |
+| ----- | -------- | ------- | ---- | ----------- |
+| `address` | false | https://provision.containership.io | string | The Containership provision API address. |
+| `tokenEnvVarName` | true | | string | The environment variable name to use to get the Containership API token. |
+| `organizationID` | true | | string | The ID of the organization to which the cluster belongs. You can find this value on the "Organization Settings" page in Containership Cloud. |
+| `clusterID` | true | | string | The ID of the cluster that should be monitored and scaled. You can find this value in your URL once you click into a cluster in Containership Cloud. |
 
 **Note:** You can acquire the Containership Cloud API key on the cluster itself by running the following command:
 ```
@@ -28,7 +28,6 @@ metadata:
 spec:
   type: containership
   configuration:
-    address:              https://provision.containership.io
     tokenEnvVarName:      CONTAINERSHIP_CLOUD_CLUSTER_API_KEY
     organizationID:       15608402-d588-48c8-b326-db14b012d83e
     clusterID:            5253100f-dc07-462e-9b93-2fc2c0d5431f

--- a/pkg/autoscaling/engines/containership/containership_test.go
+++ b/pkg/autoscaling/engines/containership/containership_test.go
@@ -81,3 +81,52 @@ func TestSetTargetNodeCount(t *testing.T) {
 	// (containership engine should default) when Containership Cloud client is easily
 	// mockable
 }
+
+func TestDefaultAndValidate(t *testing.T) {
+	c := cloudConfig{}
+	err := c.defaultAndValidate(nil)
+	assert.Error(t, err, "nil config provided is invalid")
+
+	c = cloudConfig{}
+	err = c.defaultAndValidate(map[string]string{})
+	assert.Error(t, err, "empty config provided is invalid")
+
+	configuration := map[string]string{
+		"address":         "https://provision-test.containership.io",
+		"tokenEnvVarName": "TOKEN_ENV_VAR",
+		"organizationID":  "organization-uuid",
+		"clusterID":       "cluster-uuid",
+	}
+
+	os.Setenv(configuration["tokenEnvVarName"], "token")
+
+	c = cloudConfig{}
+	err = c.defaultAndValidate(configuration)
+	assert.NoError(t, err, "good config")
+	assert.Equal(t, "https://provision-test.containership.io", c.Address, "address not defaulted if provided")
+
+	os.Unsetenv(configuration["tokenEnvVarName"])
+
+	configurationWithoutAddress := map[string]string{
+		"tokenEnvVarName": "TOKEN_ENV_VAR",
+		"organizationID":  "organization-uuid",
+		"clusterID":       "cluster-uuid",
+	}
+
+	os.Setenv(configurationWithoutAddress["tokenEnvVarName"], "token")
+
+	c = cloudConfig{}
+	err = c.defaultAndValidate(configurationWithoutAddress)
+	assert.NoError(t, err, "good config")
+	assert.Equal(t, "https://provision.containership.io", c.Address, "address defaulted if not provided")
+
+	for key := range configurationWithoutAddress {
+		c = cloudConfig{}
+		existingValue := configurationWithoutAddress[key]
+		delete(configurationWithoutAddress, key)
+		err = c.defaultAndValidate(configurationWithoutAddress)
+		assert.Error(t, err, fmt.Sprintf("Testing that an error is returned when client configuration is missing %q", key))
+		configurationWithoutAddress[key] = existingValue
+	}
+	os.Unsetenv(configurationWithoutAddress["tokenEnvVarName"])
+}


### PR DESCRIPTION
 ### Description

 #### What does this pull request accomplish?
Defaults configuration address to `https://provision.containership.io` if not provided by the user.

 #### What issue(s) does this fix?
* Fixes #77 

 #### Additional Considerations
N/A

 ### Testing

 #### Setup
N/A

 #### Instructions
Added tests for `defaultAndValidate` function which can be run via: `make test`

 ### Dependencies
* containership/cerebral#78