### PR TITLE
Fix DigitalOcean engine scale up

### DIFF
--- a/pkg/autoscaling/engines/digitalocean/configuration.go
+++ b/pkg/autoscaling/engines/digitalocean/configuration.go
@@ -1,0 +1,30 @@
+package digitalocean
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+type cloudConfig struct {
+	TokenEnvVarName  string
+	ClusterID        string
+	NodePoolLabelKey string
+}
+
+func (c *cloudConfig) defaultAndValidate(configuration map[string]string) error {
+	// Round trip the config through JSON parser to populate our struct
+	j, _ := json.Marshal(configuration)
+	json.Unmarshal(j, c)
+
+	if c.ClusterID == "" {
+		return errors.Errorf("clusterID must be provided")
+	}
+
+	if c.TokenEnvVarName == "" || os.Getenv(c.TokenEnvVarName) == "" {
+		return errors.New("tokenEnvVarName must be provided, and reference a valid env var")
+	}
+
+	return nil
+}

--- a/pkg/autoscaling/engines/digitalocean/configuration_test.go
+++ b/pkg/autoscaling/engines/digitalocean/configuration_test.go
@@ -1,0 +1,45 @@
+package digitalocean
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	// ConfigKeyClusterID is the configuration key that is used for getting the cluster ID
+	ConfigKeyClusterID = "clusterID"
+	// ConfigKeyTokenEnvVarName is the name of the configuration key that is env var
+	// which is used to get the DigitalOcean API key
+	ConfigKeyTokenEnvVarName = "tokenEnvVarName"
+	// ConfigKeyNodePoolLabelKey is the configuration key used for getting the
+	// node pool ID out of the node selector being used in an ASG
+	ConfigKeyNodePoolLabelKey = "nodePoolLabelKey"
+)
+
+func TestValidateConfiguration(t *testing.T) {
+	configuration := map[string]string{
+		ConfigKeyTokenEnvVarName: "TOKEN_ENV_VAR",
+		ConfigKeyClusterID:       "cluster-uuid",
+	}
+
+	os.Setenv(configuration[ConfigKeyTokenEnvVarName], "token")
+	defer os.Unsetenv(configuration[ConfigKeyTokenEnvVarName])
+
+	c := cloudConfig{}
+	err := c.defaultAndValidate(configuration)
+	assert.NoError(t, err)
+	assert.Equal(t, configuration[ConfigKeyTokenEnvVarName], c.TokenEnvVarName)
+	assert.Equal(t, configuration[ConfigKeyClusterID], c.ClusterID)
+
+	for key := range configuration {
+		existingValue := configuration[key]
+		delete(configuration, key)
+		c = cloudConfig{}
+		err = c.defaultAndValidate(configuration)
+		assert.Error(t, err, fmt.Sprintf("Testing that an error is returned when client configuration is missing %q", key))
+		configuration[key] = existingValue
+	}
+}

--- a/pkg/autoscaling/engines/digitalocean/digitalocean_test.go
+++ b/pkg/autoscaling/engines/digitalocean/digitalocean_test.go
@@ -80,6 +80,8 @@ func TestNewClient(t *testing.T) {
 		ConfigKeyTokenEnvVarName: "TOKEN_ENV_VAR",
 		ConfigKeyClusterID:       "cluster-uuid",
 	}
+	os.Setenv(configuration[ConfigKeyTokenEnvVarName], "token")
+	defer os.Unsetenv(configuration[ConfigKeyTokenEnvVarName])
 	name := "digitalocean"
 
 	_, err := NewClient("", configuration)
@@ -216,6 +218,25 @@ func TestGetNodepoolCount(t *testing.T) {
 
 	for _, test := range tests {
 		r := getMinNodesNeededInNodePoolCount(test.curr, test.total)
+		assert.Equal(t, test.result, r)
+	}
+}
+
+func TestGetScaleUpCount(t *testing.T) {
+	tests := []struct {
+		desired       int
+		total         int
+		nodePoolTotal int
+		result        int
+	}{
+		{5, 3, 3, 5},
+		{4, 3, 1, 2},
+		{5, 3, 1, 3},
+		{10, 4, 2, 8},
+	}
+
+	for _, test := range tests {
+		r := getScaleUpCount(test.desired, test.total, test.nodePoolTotal)
 		assert.Equal(t, test.result, r)
 	}
 }

--- a/pkg/autoscaling/engines/digitalocean/digitalocean_test.go
+++ b/pkg/autoscaling/engines/digitalocean/digitalocean_test.go
@@ -3,7 +3,6 @@ package digitalocean
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -53,25 +52,6 @@ func fakeAutoscalingEngine() *Engine {
 			ClusterID:       "cluster-uuid",
 		},
 		client: client,
-	}
-}
-
-func TestValidateConfiguration(t *testing.T) {
-	configuration := map[string]string{
-		ConfigKeyTokenEnvVarName: "TOKEN_ENV_VAR",
-		ConfigKeyClusterID:       "cluster-uuid",
-	}
-
-	os.Setenv(configuration[ConfigKeyTokenEnvVarName], "token")
-	err := validateConfiguration(configuration)
-	assert.NoError(t, err)
-
-	for key := range configuration {
-		existingValue := configuration[key]
-		delete(configuration, key)
-		err = validateConfiguration(configuration)
-		assert.Error(t, err, fmt.Sprintf("Testing that an error is returned when client configuration is missing %q", key))
-		configuration[key] = existingValue
 	}
 }
 


### PR DESCRIPTION
 ### Description

The DigitalOcean ocean engine was not properly calculating the total number of nodes that should be in a node pool in the case of scale up. This fixes the calculation to find the total number of nodes that should be in a node pool as well as adds tests. 

I also pulled out the configuration validation to a separate function and made it match the Containership engine. 

 #### What does this pull request accomplish?

 #### What issue(s) does this fix?
N/A

 #### Additional Considerations

 ### Testing
- wrote tests
- created and deployed docker image
- made sure scale up created the correct number of nodes in the node pool 

 #### Setup

`make build`

```
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  labels:
    app.kubernetes.io/name: cerebral
    containership.io/app: cerebral
  name: cerebral
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: cerebral
      containership.io/app: cerebral
  template:
    metadata:
      labels:
        app.kubernetes.io/name: cerebral
        containership.io/app: cerebral
    spec:
      containers:
      - env:
        - name: LOG_LEVEL
          value: DEBUG
        - name: DO_TOKEN
          valueFrom:
            secretKeyRef:
              key: DO_TOKEN
              name: cerebral
        image: ashleyschuett/cerebral
        imagePullPolicy: Always
        name: cerebral
      restartPolicy: Always
      serviceAccountName: cerebral
```

 #### Instructions

 ### Dependencies