### PR TITLE
add known key to digitalocean engine

### DIFF
--- a/docs/engines/digitalocean.md
+++ b/docs/engines/digitalocean.md
@@ -15,13 +15,10 @@ You can find the cluster ID in the URL when looking at the cluster through the D
 Finally, you can acquire an API token through the "Account" page on the DigitalOcean dashboard.
 **Note:** The token that is used will need to have both read and write privileges to be able to scale the node pool.
 
-There is also the option of adding `nodePoolLabelKey` which will allow for multiple Autoscaling Groups, one for each node pool, once DigitalOcean labels each node in a node pool with its node pool information.
-
 | Field | Required | Type | Description |
 | ----- | -------- | ---- | ----------- |
 | `tokenEnvVarName` | true | string | The environment variable name to use to get the DigitalOcean API token. |
 | `clusterID` | true | string | The ID of the cluster that should be monitored and scaled. |
-| `nodePoolLabelKey` | false | string | The label key that is used for labeling nodes as part of a node pool. |
 
 ## Example
 ```yaml
@@ -34,5 +31,4 @@ spec:
   configuration:
     tokenEnvVarName:      DO_TOKEN
     clusterID:            5253100f-dc07-462e-9b93-2fc2c0d5431f
-    nodePoolLabelKey:     digitalocean.com/node-pool-id
 ```

--- a/examples/engines/digitalocean/20-autoscaling-engine-digitalocean.yaml
+++ b/examples/engines/digitalocean/20-autoscaling-engine-digitalocean.yaml
@@ -8,4 +8,3 @@ spec:
   configuration:
     clusterID: 00000000-0000-0000-0000-000000000000
     tokenEnvVarName: DIGITALOCEAN_TOKEN
-    nodePoolLabelKey: node-pool-label-key

--- a/pkg/autoscaling/engines/digitalocean/configuration.go
+++ b/pkg/autoscaling/engines/digitalocean/configuration.go
@@ -8,9 +8,8 @@ import (
 )
 
 type cloudConfig struct {
-	TokenEnvVarName  string
-	ClusterID        string
-	NodePoolLabelKey string
+	TokenEnvVarName string
+	ClusterID       string
 }
 
 func (c *cloudConfig) defaultAndValidate(configuration map[string]string) error {


### PR DESCRIPTION
 ### Description

Remove the configuration option for the user to choose their own well known key for how to divide nodes in to groups. 

 #### What does this pull request accomplish?

 #### What issue(s) does this fix?
* Fixes #87 

 #### Additional Considerations

This change gets rid of a lot of DigitalOceans' engines flexibility, but also removes the burden of groups nodes of the user. This change makes the DO engine now mirror the Containership engine. Is the removal of flexibility for node groupings desired?  

 ### Testing

- created docker image and pushed to my docker registry
- ran new image on DOKS cluster
- increased CPU requests to >70% and after sample period the cluster scaled up the node pool by desired count. 

 #### Setup

 #### Instructions

 ### Dependencies
