### PR TITLE
Update getNodeExporterNodes to use Prometheus

### DIFF
--- a/pkg/controller/metrics_backend.go
+++ b/pkg/controller/metrics_backend.go
@@ -263,7 +263,7 @@ func (c *MetricsBackendController) instantiateBackend(backend *cerebralv1alpha1.
 			return nil, errors.New("Prometheus backend requires address in configuration")
 		}
 
-		return prometheus.NewClient(address, c.nodeLister, c.podLister)
+		return prometheus.NewClient(address, c.nodeLister)
 
 	case "influxdb":
 		var address string

--- a/pkg/metrics/backends/prometheus/prometheus.go
+++ b/pkg/metrics/backends/prometheus/prometheus.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/pkg/errors"
+	"strings"
 	"text/template"
 	"time"
-	"strings"
-	"github.com/pkg/errors"
 
 	prometheusclient "github.com/prometheus/client_golang/api"
 	prometheus "github.com/prometheus/client_golang/api/prometheus/v1"
@@ -123,18 +123,17 @@ func (b Backend) GetValue(metric string, configuration map[string]string, nodeSe
 	}
 }
 
-
 func (b Backend) getNodeExporterPodIPsOnNodes(nodes []*corev1.Node) ([]string, error) {
 	var podIPs []string
 	//Filter only prom-exporter job, furhter filter down by node ips
 	targets, _ := b.prometheus.Targets(context.TODO())
 	for _, active := range targets.Active {
 		jobName := string(active.DiscoveredLabels["job"])
-		split := strings.Split(jobName,"/")
-		if(split[1] == "node-export-monitor"){
-			for _, node := range nodes{
-				if(string(active.DiscoveredLabels["__meta_kubernetes_pod_node_name"]) == node.ObjectMeta.Name){
-					podIPs = append(podIPs,string(active.DiscoveredLabels["__meta_kubernetes_pod_ip"]))
+		split := strings.Split(jobName, "/")
+		if split[1] == "node-export-monitor" {
+			for _, node := range nodes {
+				if string(active.DiscoveredLabels["__meta_kubernetes_pod_node_name"]) == node.ObjectMeta.Name {
+					podIPs = append(podIPs, string(active.DiscoveredLabels["__meta_kubernetes_pod_ip"]))
 				}
 			}
 		}

--- a/pkg/metrics/backends/prometheus/prometheus.go
+++ b/pkg/metrics/backends/prometheus/prometheus.go
@@ -39,9 +39,6 @@ const cpuQueryTemplateString = `
 	) * 100
 )`
 
-
-
-
 var cpuQueryTemplate = template.Must(template.New("cpu").Parse(cpuQueryTemplateString))
 
 // Average memory usage across the given nodes for the given range

--- a/pkg/metrics/backends/prometheus/prometheus_test.go
+++ b/pkg/metrics/backends/prometheus/prometheus_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/prometheus/common/model"
 	prometheus "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,7 +52,6 @@ var (
 
 	podIP0 = "192.168.0.1"
 	podIP1 = "192.168.1.1"
-
 )
 
 var (
@@ -106,20 +105,20 @@ var (
 
 	dlNode0 = model.LabelSet{
 		"__meta_kubernetes_pod_node_name": model.LabelValue(promPodOnNode0.Spec.NodeName),
-		"__meta_kubernetes_pod_ip": model.LabelValue(promPodOnNode0.Status.PodIP),
-		"job": "random/node-export-monitor/random",
+		"__meta_kubernetes_pod_ip":        model.LabelValue(promPodOnNode0.Status.PodIP),
+		"job":                             "random/node-export-monitor/random",
 	}
 
 	dlNode1 = model.LabelSet{
 		"__meta_kubernetes_pod_node_name": model.LabelValue(promPodOnNode1.Spec.NodeName),
-		"__meta_kubernetes_pod_ip": model.LabelValue(promPodOnNode1.Status.PodIP),
-		"job": "random/node-export-monitor/random",
+		"__meta_kubernetes_pod_ip":        model.LabelValue(promPodOnNode1.Status.PodIP),
+		"job":                             "random/node-export-monitor/random",
 	}
 
 	dlOtherNode = model.LabelSet{
 		"__meta_kubernetes_pod_node_name": "other-0",
-		"__meta_kubernetes_pod_ip": "1.1.1.192",
-		"job": "random/cadvisor/random",
+		"__meta_kubernetes_pod_ip":        "1.1.1.192",
+		"job":                             "random/cadvisor/random",
 	}
 )
 
@@ -149,21 +148,20 @@ func TestGetValue(t *testing.T) {
 	mockProm.On("Query", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, fmt.Errorf("some prometheus error")).Once()
 
-	mockProm.On("Targets",mock.Anything).Return(
-	prometheus.TargetsResult{
-		Active: []prometheus.ActiveTarget {
-			{
-				DiscoveredLabels: dlNode0,
+	mockProm.On("Targets", mock.Anything).Return(
+		prometheus.TargetsResult{
+			Active: []prometheus.ActiveTarget{
+				{
+					DiscoveredLabels: dlNode0,
+				},
+				{
+					DiscoveredLabels: dlNode1,
+				},
+				{
+					DiscoveredLabels: dlOtherNode,
+				},
 			},
-			{
-				DiscoveredLabels: dlNode1,
-			},
-			{
-				DiscoveredLabels: dlOtherNode,
-			},
-		},
-	},nil)
-
+		}, nil)
 
 	backend := Backend{
 		prometheus: &mockProm,
@@ -227,9 +225,9 @@ func TestGetNodeExporterPodIPsOnNodes(t *testing.T) {
 	emptyPodLister := buildPodLister(nil)
 
 	mockProm := mocks.API{}
-	mockProm.On("Targets",mock.Anything).Return(
+	mockProm.On("Targets", mock.Anything).Return(
 		prometheus.TargetsResult{
-			Active: []prometheus.ActiveTarget {
+			Active: []prometheus.ActiveTarget{
 				{
 					DiscoveredLabels: dlNode0,
 				},
@@ -240,7 +238,7 @@ func TestGetNodeExporterPodIPsOnNodes(t *testing.T) {
 					DiscoveredLabels: dlOtherNode,
 				},
 			},
-		},nil)
+		}, nil)
 
 	backend := Backend{
 		prometheus: &mockProm,

--- a/pkg/metrics/backends/prometheus/prometheus_test.go
+++ b/pkg/metrics/backends/prometheus/prometheus_test.go
@@ -125,23 +125,19 @@ var (
 func TestNewClient(t *testing.T) {
 	// Should never fail with any valid URL because it's only constructing an
 	// http.Client under the hood
-	client, err := NewClient(validURL, corelistersv1.NewNodeLister(nil), corelistersv1.NewPodLister(nil))
+	client, err := NewClient(validURL, corelistersv1.NewNodeLister(nil))
 	assert.NotNil(t, client)
 	assert.NoError(t, err, "any valid URL is ok")
 
-	client, err = NewClient("", corelistersv1.NewNodeLister(nil), corelistersv1.NewPodLister(nil))
+	client, err = NewClient("", corelistersv1.NewNodeLister(nil))
 	assert.Error(t, err, "error on empty URL")
 
-	_, err = NewClient(validURL, nil, corelistersv1.NewPodLister(nil))
+	_, err = NewClient(validURL, nil)
 	assert.Error(t, err, "error on nil NodeLister")
-
-	_, err = NewClient(validURL, corelistersv1.NewNodeLister(nil), nil)
-	assert.Error(t, err, "error on nil PodLister")
 }
 
 func TestGetValue(t *testing.T) {
 	nodeLister := kubernetestest.BuildNodeLister(nil)
-	podLister := buildPodLister(nil)
 
 	mockProm := mocks.API{}
 	// Return error
@@ -166,7 +162,6 @@ func TestGetValue(t *testing.T) {
 	backend := Backend{
 		prometheus: &mockProm,
 		nodeLister: nodeLister,
-		podLister:  podLister,
 	}
 
 	_, err := backend.GetValue("cpu_percent_utilization", goodConfiguration, nil)
@@ -222,8 +217,6 @@ func TestGetValue(t *testing.T) {
 }
 
 func TestGetNodeExporterPodIPsOnNodes(t *testing.T) {
-	emptyPodLister := buildPodLister(nil)
-
 	mockProm := mocks.API{}
 	mockProm.On("Targets", mock.Anything).Return(
 		prometheus.TargetsResult{
@@ -242,7 +235,6 @@ func TestGetNodeExporterPodIPsOnNodes(t *testing.T) {
 
 	backend := Backend{
 		prometheus: &mockProm,
-		podLister:  emptyPodLister,
 	}
 
 	// Empty cache but no nodes requested


### PR DESCRIPTION
 ### Description


 #### What does this pull request accomplish?
Eliminates the need to use a label selector in favor of the prometheus Targets api call, which gets rid of needing to hard code "prom-exporter". All changes made to the getNodeExporterPodIPsOnNodes function.  
 #### What issue(s) does this fix?
* Fixes #15 

 ### Testing
No changes to the existing tests
Only tested using Unit Tests